### PR TITLE
fix:default port prompt when nest.js starts

### DIFF
--- a/example/nestjs-react-ssr/src/main.ts
+++ b/example/nestjs-react-ssr/src/main.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { NestFactory } from '@nestjs/core'
 import { NestExpressApplication } from '@nestjs/platform-express'
-import { initialSSRDevProxy } from 'ssr-server-utils'
+import { initialSSRDevProxy, loadConfig } from 'ssr-server-utils'
 
 import { AppModule } from './app.module'
 
@@ -12,7 +12,8 @@ async function bootstrap (): Promise<void> {
   })
   app.useStaticAssets(join(process.cwd(), './build'))
 
-  await app.listen(3000)
+  const config = loadConfig()
+  await app.listen(config.serverPort)
 }
 
 bootstrap().catch(err => {

--- a/packages/plugin-nestjs/src/start.ts
+++ b/packages/plugin-nestjs/src/start.ts
@@ -1,9 +1,10 @@
 import { exec } from 'child_process'
-import { logGreen } from 'ssr-server-utils'
+import { logGreen, loadConfig } from 'ssr-server-utils'
 
 const spinner = require('ora')('starting ')
 
 const start = () => {
+  const config = loadConfig()
   spinner.start()
   const { stdout, stderr } = exec('npx nest start --watch', {} /* options, [optional] */)
   stdout?.on('data', function (data) {
@@ -11,7 +12,7 @@ const start = () => {
     if (data.match('Nest application successfully started')) {
       spinner.stop()
       const https = process.env.HTTPS
-      logGreen(`Server is listening on ${https ? 'https' : 'http'}://localhost:3000`)
+      logGreen(`Server is listening on ${https ? 'https' : 'http'}://localhost:${config.serverPort}`)
     }
   })
   stderr?.on('data', function (data) {


### PR DESCRIPTION
修复nestjs下端口默认提示为3000的问题