### PR TITLE
fix(script): chmod cause error on win32 platform

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,6 +1,11 @@
 const fs = require('fs')
+const os = require('os')
 const { execSync } = require('child_process')
 const argv = require('./minimist')(process.argv.slice(2))
+
+function isWin () {
+  return os.platform() === 'win32'
+}
 
 const options = {
   stdio: 'inherit'
@@ -58,7 +63,9 @@ if (argv.link) {
   const examples = fs.readdirSync('./example')
   examples.forEach(example => {
     if (example !== '.DS_Store') {
-      const exampleShell = shell + `&& cd example/${example} && yarn link ${linkedPackage} && chmod 777 ./node_modules/ssr/cjs/cli.js`
+      const commonShell = `${shell} && cd example/${example} && yarn link ${linkedPackage}`
+      const grantExecutePermission = 'chmod 777 ./node_modules/ssr/cjs/cli.js'
+      const exampleShell = isWin() ? commonShell : `${commonShell} && ${grantExecutePermission}`
       execSync(exampleShell, options)
     }
   })


### PR DESCRIPTION
当执行 `npx lerna bootstrap` 时会调用到 `node scripts/scripts.js --link`，这个脚本中的 `chmod ...` 部分会导致在 windows 下执行抛出异常。

我添加了一个 isWin() 的判断函数通过 os.platform() === 'win32' 来判断是否追加 `chmod ...` 的部分，大部分情况下 windows 下不需要单独为文件授予可执行权限。