### PR TITLE
feat: add location prop to StaticRouter

### DIFF
--- a/packages/plugin-react/src/entry/server-entry.tsx
+++ b/packages/plugin-react/src/entry/server-entry.tsx
@@ -110,7 +110,7 @@ const serverRender = async (ctx: ISSRContext, config: IConfig): Promise<React.Re
   }} />
 
   return (
-    <StaticRouter>
+    <StaticRouter location={ctx.request.url}>
       <Context.Provider value={{ state: combineData }}>
         <Layout ctx={ctx} config={config} staticList={staticList} injectState={injectState}>
           {isCsr ? <></> : <Component />}


### PR DESCRIPTION
This commit makes react router hooks (i.e., useLocation and useRouteMatch) valid in ssr mode.

Related doc: https://v5.reactrouter.com/web/api/StaticRouter/location-string