### PR TITLE
fix(vite): vite config base use publicPath first in client

### DIFF
--- a/packages/plugin-react/src/tools/vite.ts
+++ b/packages/plugin-react/src/tools/vite.ts
@@ -1,8 +1,8 @@
 import { build, UserConfig } from 'vite'
-import { loadConfig, chunkNamePlugin, rollupOutputOptions, manifestPlugin, commonConfig, asyncOptimizeChunkPlugin } from 'ssr-server-utils'
+import { loadConfig, chunkNamePlugin, rollupOutputOptions, manifestPlugin, commonConfig, asyncOptimizeChunkPlugin, getOutputPublicPath } from 'ssr-server-utils'
 import react from '@vitejs/plugin-react'
 import styleImport, { AndDesignVueResolve, VantResolve, ElementPlusResolve, NutuiResolve, AntdResolve } from 'vite-plugin-style-import'
-const { getOutput, prefix, reactServerEntry, reactClientEntry, viteConfig, supportOptinalChaining, isDev, define, babelOptions } = loadConfig()
+const { getOutput, prefix, publicPath, reactServerEntry, reactClientEntry, viteConfig, supportOptinalChaining, isDev, define, babelOptions } = loadConfig()
 const { clientOutPut, serverOutPut } = getOutput()
 const styleImportConfig = {
   include: ['**/*.vue', '**/*.ts', '**/*.js', '**/*.tsx', '**/*.jsx', /chunkName/],
@@ -52,9 +52,11 @@ const serverConfig: UserConfig = {
   }
 }
 
+// 配置了 publicPath 则使用 getOutputPublicPath，否则使用 prefix
+const clientBase = publicPath ? getOutputPublicPath() : prefix
 const clientConfig: UserConfig = {
   ...commonConfig(),
-  base: isDev ? '/' : prefix,
+  base: isDev ? '/' : clientBase,
   esbuild: {
     keepNames: true
   },

--- a/packages/plugin-vue3/src/tools/vite.ts
+++ b/packages/plugin-vue3/src/tools/vite.ts
@@ -1,11 +1,11 @@
 import { build, UserConfig } from 'vite'
-import { loadConfig, chunkNamePlugin, rollupOutputOptions, manifestPlugin, commonConfig, asyncOptimizeChunkPlugin } from 'ssr-server-utils'
+import { loadConfig, chunkNamePlugin, rollupOutputOptions, manifestPlugin, commonConfig, asyncOptimizeChunkPlugin, getOutputPublicPath } from 'ssr-server-utils'
 import vuePlugin from '@vitejs/plugin-vue'
 import vueJSXPlugin from '@vitejs/plugin-vue-jsx'
 import babel from '@rollup/plugin-babel'
 import styleImport, { AndDesignVueResolve, VantResolve, ElementPlusResolve, NutuiResolve, AntdResolve } from 'vite-plugin-style-import'
 
-const { getOutput, prefix, vue3ServerEntry, vue3ClientEntry, viteConfig, supportOptinalChaining, isDev, define, babelOptions } = loadConfig()
+const { getOutput, prefix, publicPath, vue3ServerEntry, vue3ClientEntry, viteConfig, supportOptinalChaining, isDev, define, babelOptions } = loadConfig()
 const { clientOutPut, serverOutPut } = getOutput()
 
 const styleImportConfig = {
@@ -56,9 +56,11 @@ const serverConfig: UserConfig = {
   }
 }
 
+// 配置了 publicPath 则使用 getOutputPublicPath，否则使用 prefix
+const clientBase = publicPath ? getOutputPublicPath() : prefix
 const clientConfig: UserConfig = {
   ...commonConfig(),
-  base: isDev ? '/' : prefix,
+  base: isDev ? '/' : clientBase,
   plugins: [
     vuePlugin(viteConfig?.()?.client?.defaultPluginOptions),
     vueJSXPlugin(),


### PR DESCRIPTION
升级原因：修复 vite 下配置 publicPath 静态资源链接错误的问题
关注点：使用 vite 且用 cdn 部署静态资源的用户
