### PR TITLE
fix: add prefix output to window.prefix in csr mode

### DIFF
--- a/packages/plugin-react/src/entry/server-entry.tsx
+++ b/packages/plugin-react/src/entry/server-entry.tsx
@@ -68,7 +68,7 @@ const serverRender = async (ctx: ISSRContext, config: IConfig): Promise<React.Re
     }
   }
   const combineData = isCsr ? null : Object.assign(state ?? {}, layoutFetchData ?? {}, fetchData ?? {})
-  const injectState = isCsr ? null : <script dangerouslySetInnerHTML={{
+  const injectState = isCsr ? <script dangerouslySetInnerHTML={{ __html: `window.prefix="${prefix}"` }} /> : <script dangerouslySetInnerHTML={{
     __html: `window.__USE_SSR__=true; window.__INITIAL_DATA__ =${serialize(combineData)}; window.prefix="${prefix}";${clientPrefix && `window.clientPrefix="${clientPrefix}"`}`
   }} />
 

--- a/packages/plugin-vue/src/entry/server-entry.ts
+++ b/packages/plugin-vue/src/entry/server-entry.ts
@@ -116,7 +116,7 @@ const serverRender = async (ctx: ISSRContext, config: IConfig): Promise<Vue.Comp
           }, [
             isCsr ? h('script', {
               domProps: {
-                innerHTML: `window.__USE_VITE__=${isVite}`
+                innerHTML: `window.__USE_VITE__=${isVite}; window.prefix="${prefix}"`
               }
             }) : h('script', {
               domProps: {

--- a/packages/plugin-vue3/src/entry/server-entry.ts
+++ b/packages/plugin-vue3/src/entry/server-entry.ts
@@ -49,7 +49,7 @@ const serverRender = async (ctx: ISSRContext, config: IConfig) => {
 
         initialData: !isCsr ? () => h('script', {
           innerHTML: `window.__USE_SSR__=true; window.__INITIAL_DATA__ = ${serialize(state)};window.__INITIAL_PINIA_DATA__ = ${serialize(pinia.state.value)};window.__USE_VITE__=${isVite}; window.prefix="${prefix}" ;${clientPrefix && `window.clientPrefix="${clientPrefix}"`};`
-        }) : () => h('script', { innerHTML: `window.__USE_VITE__=${isVite}` }),
+        }) : () => h('script', { innerHTML: `window.__USE_VITE__=${isVite}; window.prefix="${prefix}"` }),
 
         cssInject: () => injectCss,
 


### PR DESCRIPTION
https://github.com/zhangyuang/ssr/commit/55ba49197f6c75053ace188947813e9527a4b25a

在这个 commit 下移除了 PrefixRouterBase，client-entry 改用 window.prefix。在 csr mode 下并没有输出 window.prefix 导致路由匹配失败。故添加 csr mode 下的 server output window.prefix