### PR TITLE
fix: Recommended to specify used minor core-js version

### DIFF
--- a/packages/server-utils/src/loadConfig.ts
+++ b/packages/server-utils/src/loadConfig.ts
@@ -97,11 +97,14 @@ const loadConfig = (): IConfig => {
 
   const dynamic = true
   // ref https://www.babeljs.cn/docs/babel-preset-env#corejs
-  const corejsVersion = loadModuleFromFramework('core-js/package.json') && coerce(require(loadModuleFromFramework('core-js/package.json')).version)!.major
+  const corejsVersion = loadModuleFromFramework('core-js/package.json') && coerce(require(loadModuleFromFramework('core-js/package.json')).version)
+  const corejsVersionMajor = corejsVersion!.major
+  const corejsVersionMinor = corejsVersion!.minor
+
   const corejsOptions = userConfig.corejs ? {
     corejs: {
-      version: corejsVersion,
-      proposals: corejsVersion === 3
+      version: `${corejsVersionMajor}.${corejsVersionMinor}`,
+      proposals: corejsVersionMajor === 3
     },
     targets: {
       chrome: '60',
@@ -111,7 +114,7 @@ const loadConfig = (): IConfig => {
       edge: '17'
     },
     useBuiltIns: 'usage',
-    shippedProposals: corejsVersion === 2,
+    shippedProposals: corejsVersionMajor === 2,
     ...userConfig.corejsOptions
   } : {}
 


### PR DESCRIPTION
Warning! Recommended to specify used minor core-js version, like corejs: '3.22', instead of corejs: 3, since with corejs: 3 will not be injected modules which were added in minor core-js releases.

issue link: https://github.com/zloirock/core-js/issues/1089