### PR TITLE
fix: react router basename in server entry

### DIFF
--- a/packages/plugin-react/src/entry/server-entry.tsx
+++ b/packages/plugin-react/src/entry/server-entry.tsx
@@ -73,7 +73,7 @@ const serverRender = async (ctx: ISSRContext, config: IConfig): Promise<React.Re
   }} />
 
   return (
-    <StaticRouter location={ctx.request.url}>
+    <StaticRouter location={ctx.request.url} basename={prefix}>
       <Context.Provider value={{ state: combineData }}>
         <Layout ctx={ctx} config={config} staticList={staticList} injectState={injectState}>
           <Component />


### PR DESCRIPTION
Keep same with csr mode