### PR TITLE
给示例项目midway-react18-ssr添加依赖

### DIFF
--- a/example/midway-react18-ssr/package.json
+++ b/example/midway-react18-ssr/package.json
@@ -3,17 +3,18 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@midwayjs/bootstrap": "^3.0.0",
     "@midwayjs/core": "^3.0.0",
     "@midwayjs/decorator": "^3.0.0",
     "@midwayjs/koa": "^3.0.0",
     "koa-static-cache": "^5.1.4",
+    "pm2": "^4.5.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^5.1.2",
-    "ssr-core": "^6.0.0",
     "ssr-common-utils": "^6.0.0",
-    "pm2": "^4.5.4"
+    "ssr-core": "^6.0.0"
   },
   "devDependencies": {
     "@midwayjs/mock": "^3.0.0",


### PR DESCRIPTION
demo项目安装完依赖以后，报依赖@babel/plugin-proposal-private-property-in-object缺失，手动添加依赖
