### PR TITLE
feat: allow defaultScriptProps to be a function for providing props according to the script src

### DIFF
--- a/packages/plugin-vue3/src/entry/server-entry.ts
+++ b/packages/plugin-vue3/src/entry/server-entry.ts
@@ -217,11 +217,11 @@ const serverRender = async (ctx: ISSRContext, config: IConfig) => {
 				: extraJsOrder
 						.map((js) => manifest[js])
 						.filter(Boolean)
-						.map((js) =>
+						.map((js) => 
 							h('script', {
 								src: js,
 								type: isVite ? 'module' : 'text/javascript',
-								...(config.defaultScriptProps ?? {})
+								...(typeof config.defaultScriptProps === 'function' ? config.defaultScriptProps(js) : config.defaultScriptProps ?? {})
 							})
 						)
 

--- a/packages/types/src/config.ts
+++ b/packages/types/src/config.ts
@@ -124,7 +124,7 @@ export type IConfig<T extends ToolType = ToolType> = {
 	bigpipe?: boolean
 	customeHeadScript?: ((ctx: ISSRContext) => Script) | Script
 	customeFooterScript?: ((ctx: ISSRContext) => Script) | Script
-	defaultScriptProps?: Record<string, string>
+	defaultScriptProps?: Record<string, string> | ((src: string) => Record<string, string>)
 	locale?: {
 		enable: boolean
 	}


### PR DESCRIPTION
ssr render 组装 HTML 过程中，script 具体需要加什么 attributes，可能会需要根据脚本的 src 来，比如需要对已知某些域名（跨域）的脚本加上 `crossorigin="anonymous"` 来捕获它抛出的错误，但对其他域名的脚本，不需要添加，所以希望能允许 defaultScriptProps 是一个函数，提供一个参数，即脚本的 src，让框架使用方能更灵活地添加 attrs。